### PR TITLE
Add the style attribute to the example on the "components" doc page

### DIFF
--- a/docs/src/pages/docs/components/echart.mdx
+++ b/docs/src/pages/docs/components/echart.mdx
@@ -21,6 +21,10 @@ function App() {
     <EChart
       renderer={'svg'}
       onClick={() => console.log('clicked!')}
+      style={{
+        height: '600px',
+        width: '100%'
+      }}
       xAxis={{
         type: 'category'
       }}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #29  <!-- Github issue # here -->

## 📝 Description

Please check #29 

## ⛳️ Current behavior (updates)


When executing the example code I got nothing but the warning below in the console:

```
[ECharts] Can't get DOM width or height. Please check dom.clientWidth and dom.clientHeight. They should not be 0.For example, you may need to call this in the callback of window.onload.
```

## 🚀 New behavior

It works after adding the style attribute.

![image](https://github.com/hugocxl/react-echarts/assets/96770540/393c7b61-7918-4bb3-9947-2325dd7c9950)


## 💣 Is this a breaking change (Yes/No)

No

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information
