### PR TITLE
Stop the animation from resetting each time the options are changed

### DIFF
--- a/src/use-echarts.ts
+++ b/src/use-echarts.ts
@@ -176,7 +176,12 @@ export function useECharts<T extends HTMLElement>({
   useEffect(() => {
     if (!echartsInstance) return
 
-    echartsInstance.clear()
+    return () => echartsInstance.clear()
+  }, [echartsInstance])
+
+  useEffect(() => {
+    if (!echartsInstance) return
+
     echartsInstance.setOption(
       {
         series,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #25 <!-- Github issue # here -->

## 📝 Description

Move the clear hook to a new "useEffect" to prevent the chart from being re-rendered every time the options change

This commit maintains the capability to clear the chart when the component that calls this hook is unmounted.

## ⛳️ Current behavior (updates)

The current `use-echarts` hook clears the chart each time the options is changed. BTW, we only need to clear the chart instance when the component calling this hook is unmounted.

## 🚀 New behavior

The `clear()` function will only be called when 1) the echarts instance exists; 2) React runs the cleanup function.

## 💣 Is this a breaking change (Yes/No)

No.

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information

I've tested this change locally using the example provided in #25 . If you'd like, I can also add an example to the example folder (perhaps renaming it to examples).
